### PR TITLE
Enable header theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,25 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="style.css">
     <title>Brutal Design</title>
     <style>
-        
+
     </style>
+    <script>
+        (function () {
+            try {
+                const storedTheme = localStorage.getItem('theme');
+                if (storedTheme) {
+                    document.documentElement.setAttribute('data-theme', storedTheme);
+                }
+            } catch (error) {
+                /* localStorage might be unavailable (e.g. privacy mode). */
+            }
+        })();
+    </script>
 </head>
 <body>
 
@@ -18,9 +30,9 @@
             <a href="#">WORK</a>
             <a href="#">CONTACT</a>
         </nav>
-        <menu class="">
-            <a href="#">LIGHT</a>
-            <a href="#">DARK</a>
+        <menu class="theme-toggle" aria-label="Theme toggle">
+            <button type="button" data-theme="light">LIGHT</button>
+            <button type="button" data-theme="dark">DARK</button>
         </menu>
     </header>
     
@@ -107,9 +119,48 @@
             <p>© BRUTAL DESIGN 2024</p>
         </div>
     </footer>
-    
-    
 
-    
+
+
+
+    <script>
+        (function () {
+            const THEME_STORAGE_KEY = 'theme';
+            const root = document.documentElement;
+            const toggleButtons = document.querySelectorAll('.theme-toggle [data-theme]');
+
+            function applyTheme(theme) {
+                root.setAttribute('data-theme', theme);
+                toggleButtons.forEach((button) => {
+                    const isActive = button.dataset.theme === theme;
+                    button.classList.toggle('is-active', isActive);
+                    button.setAttribute('aria-pressed', String(isActive));
+                });
+            }
+
+            let storedTheme = null;
+            try {
+                storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+            } catch (error) {
+                storedTheme = null;
+            }
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+            applyTheme(initialTheme);
+
+            toggleButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    const theme = button.dataset.theme;
+                    applyTheme(theme);
+                    try {
+                        localStorage.setItem(THEME_STORAGE_KEY, theme);
+                    } catch (error) {
+                        /* localStorage might be unavailable (e.g. privacy mode). */
+                    }
+                });
+            });
+        })();
+    </script>
+
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -7,13 +7,22 @@
 
 
 :root {
-    --c-text: #000;
-    --c-bg: #fff;
-    /*
+    color-scheme: dark;
     --c-text: #fff;
     --c-bg: #000;
-    */
     --ff: 'Courier New', Courier, monospace;
+}
+
+:root[data-theme="light"] {
+    color-scheme: light;
+    --c-text: #000;
+    --c-bg: #fff;
+}
+
+:root[data-theme="dark"] {
+    color-scheme: dark;
+    --c-text: #fff;
+    --c-bg: #000;
 }
 
 
@@ -21,9 +30,10 @@
 body {
     font-family: var(--ff);
     /* font-family: 'Times New Roman', Times, serif, monospace; */
-    background: var(--c-text);
-    color: var(--c-bg);
+    background: var(--c-bg);
+    color: var(--c-text);
     line-height: 1.6;
+    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 
@@ -47,43 +57,50 @@ header {
 
 nav.nav,
 menu {
-    /* background: var(--c-bg); */
-    /* padding: 20px; */
-    /* border: 3px solid #000; */
-    /* padding-inline: 3em; */
     padding-inline: 6em;
-    /* padding-block: 2em; */
-
-
-    /* background-color: var(--c-bg); */
-    /*  padding: 2px;*/
-
     display: flex;
     gap: 2px;
-    /*  background-color: var(--c-text); */ 
     padding: 2px;
-    /* border: 1px solid var(--c-text); */
+    list-style: none;
+}
 
-    a {
-        background-color: var(--c-bg);
-        /* color: #fff; */
-        /*
-        
-        text-decoration: none;
+nav.nav a,
+menu a,
+menu button {
+    background-color: var(--c-bg);
+    color: var(--c-text);
+    text-decoration: none;
+    font-size: 24px;
+    font-weight: bold;
+    padding: 2em 3em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+    border: 1px solid var(--c-text);
+    border-right: 0;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
 
-        */
-        /* add this to: how to make any siote trend=brutalis! */
+nav.nav a:not(:last-child),
+menu a:not(:last-child),
+menu button:not(:last-child) {
+    border-right: 1px solid var(--c-text);
+}
 
-        font-size: 24px;
-        font-weight: bold;
-        padding: 2em 3em;
-        display: inline-block;
+menu button {
+    font: inherit;
+    cursor: pointer;
+}
 
+.theme-toggle button.is-active {
+    background-color: var(--c-text);
+    color: var(--c-bg);
+}
 
-        border-right: 1px solid var(--c-text);
-
-    }    
-
+.theme-toggle button:focus-visible {
+    outline: 2px dashed var(--c-text);
+    outline-offset: 4px;
 }
 
 


### PR DESCRIPTION
## Summary
- add a dedicated light/dark toggle to the header with persistent selection
- align color variables to support both themes and update navigation styling
- respect system preferences while guarding against unavailable localStorage access

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68cc74c449908326bdd09b1fa9d7462a