### PR TITLE
Reset anchor colors to inherit

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,6 +5,15 @@
 }
 
 
+a,
+a:visited,
+a:hover,
+a:focus,
+a:active {
+    color: inherit;
+}
+
+
 
 :root {
     --c-text: #000;


### PR DESCRIPTION
## Summary
- ensure all anchor states inherit surrounding text color to match design palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc750d9e108326b9e329f8f0862724