### PR TITLE
Add responsive hamburger menu for mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,16 +12,23 @@
 <body>
 
     <header>
-        <nav class="nav">
+        <nav class="nav" id="primary-navigation">
             <a href="#">HOME</a>
             <a href="#">ABOUT</a>
             <a href="#">WORK</a>
             <a href="#">CONTACT</a>
         </nav>
-        <menu class="">
-            <a href="#">LIGHT</a>
-            <a href="#">DARK</a>
-        </menu>
+        <div class="header-controls">
+            <menu class="">
+                <a href="#">LIGHT</a>
+                <a href="#">DARK</a>
+            </menu>
+            <button class="hamburger" type="button" aria-label="Toggle navigation" aria-controls="primary-navigation" aria-expanded="false">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+        </div>
     </header>
     
     <div class="hero">
@@ -111,5 +118,18 @@
     
 
     
+
+    <script>
+        const hamburger = document.querySelector('.hamburger');
+        const navigation = document.getElementById('primary-navigation');
+
+        if (hamburger && navigation) {
+            hamburger.addEventListener('click', () => {
+                const isExpanded = hamburger.getAttribute('aria-expanded') === 'true';
+                hamburger.setAttribute('aria-expanded', (!isExpanded).toString());
+                navigation.classList.toggle('is-open', !isExpanded);
+            });
+        }
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -40,8 +40,33 @@ header {
     padding-inline: 3em;
     padding-inline: 6em;
     */
-    
-    
+
+
+}
+
+
+.header-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.hamburger {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 6px;
+    background: transparent;
+    border: 1px solid var(--c-text);
+    padding: 12px 10px;
+    cursor: pointer;
+}
+
+.hamburger span {
+    width: 24px;
+    height: 2px;
+    background-color: var(--c-text);
+    display: block;
 }
 
 
@@ -358,7 +383,7 @@ section {
     border-top: 1px solid var(--c-text);
     background-color: var(--c-bg);
     color: var(--c-text);
-    
+
     padding-inline: 3em;
     /* padding-inline: 6em; */
     /* padding-block: 3em;*/
@@ -372,7 +397,7 @@ section {
     gap: 40px;
 
     /* padding-block: 6em; */
-    padding-block: 4em; 
+    padding-block: 4em;
 }
 
 .footer-item a {
@@ -387,5 +412,57 @@ section {
 
 .footer-bottom {
     /* border-top: 1px solid var(--c-text); */
-    padding-block: 2em;  
+    padding-block: 2em;
+}
+
+
+@media (max-width: 768px) {
+    header {
+        flex-wrap: wrap;
+        gap: 1.5em;
+        padding-inline: 1.5em;
+    }
+
+    .header-controls {
+        width: 100%;
+        justify-content: flex-end;
+    }
+
+    nav.nav,
+    menu {
+        padding: 0;
+        padding-inline: 1.5em;
+    }
+
+    nav.nav {
+        display: none;
+        flex-direction: column;
+        width: 100%;
+        padding-block: 1em;
+        gap: 0;
+        border-top: 1px solid var(--c-text);
+    }
+
+    nav.nav.is-open {
+        display: flex;
+    }
+
+    nav.nav a {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--c-text);
+        padding: 1em 0.5em;
+    }
+
+    nav.nav a:last-child {
+        border-bottom: none;
+    }
+
+    menu a {
+        padding: 1em 1.5em;
+    }
+
+    .hamburger {
+        display: inline-flex;
+    }
 }


### PR DESCRIPTION
## Summary
- add a hamburger toggle button beside the theme controls in the header
- add a small script to toggle the primary navigation on mobile
- add responsive styles so the navigation drops down beneath the header controls on small screens

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cc75ee8fdc83268754b09869d86153