### PR TITLE
Add responsive hamburger navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,13 @@
 <body>
 
     <header>
-        <nav class="nav">
+        <button type="button" class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+        </button>
+        <nav class="nav" id="primary-navigation">
             <a href="#">HOME</a>
             <a href="#">ABOUT</a>
             <a href="#">WORK</a>
@@ -159,6 +165,43 @@
                     }
                 });
             });
+        })();
+
+        (function () {
+            const nav = document.querySelector('.nav');
+            const toggle = document.querySelector('.nav-toggle');
+            if (!nav || !toggle) {
+                return;
+            }
+
+            function closeNav() {
+                toggle.setAttribute('aria-expanded', 'false');
+                nav.classList.remove('is-open');
+            }
+
+            toggle.addEventListener('click', () => {
+                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                const nextState = !isExpanded;
+                toggle.setAttribute('aria-expanded', String(nextState));
+                nav.classList.toggle('is-open', nextState);
+            });
+
+            nav.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', () => {
+                    if (window.matchMedia('(max-width: 768px)').matches) {
+                        closeNav();
+                    }
+                });
+            });
+
+            const mq = window.matchMedia('(min-width: 769px)');
+            if (typeof mq.addEventListener === 'function') {
+                mq.addEventListener('change', closeNav);
+            } else if (typeof mq.addListener === 'function') {
+                mq.addListener(closeNav);
+            }
+
+            closeNav();
         })();
     </script>
 

--- a/style.css
+++ b/style.css
@@ -91,6 +91,53 @@ menu button {
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+.nav-toggle {
+    display: none;
+    background-color: var(--c-bg);
+    color: var(--c-text);
+    border: 1px solid var(--c-text);
+    padding: 1.5em;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.nav-toggle__bar {
+    display: block;
+    width: 24px;
+    height: 2px;
+    background-color: currentColor;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-toggle__bar + .nav-toggle__bar {
+    margin-top: 6px;
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-of-type(2) {
+    transform: translateY(8px) rotate(45deg);
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-of-type(3) {
+    opacity: 0;
+}
+
+.nav-toggle[aria-expanded="true"] .nav-toggle__bar:nth-of-type(4) {
+    transform: translateY(-8px) rotate(-45deg);
+}
+
 nav.nav a:not(:last-child),
 menu a:not(:last-child),
 menu button:not(:last-child) {
@@ -110,6 +157,67 @@ menu button {
 .theme-toggle button:focus-visible {
     outline: 2px dashed var(--c-text);
     outline-offset: 4px;
+}
+
+@media (max-width: 768px) {
+    header {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 1.5em;
+        padding: 1.5em;
+    }
+
+    .nav-toggle {
+        display: inline-flex;
+        align-self: flex-end;
+        padding: 1em;
+    }
+
+    nav.nav,
+    menu {
+        padding-inline: 0;
+        width: 100%;
+    }
+
+    nav.nav {
+        display: none;
+        flex-direction: column;
+        border: 1px solid var(--c-text);
+    }
+
+    nav.nav.is-open {
+        display: flex;
+    }
+
+    nav.nav a,
+    menu button {
+        padding: 1.25em;
+        width: 100%;
+        border: 0;
+        border-right: none;
+    }
+
+    nav.nav a {
+        border-bottom: 1px solid var(--c-text);
+    }
+
+    nav.nav a:last-child {
+        border-bottom: 0;
+    }
+
+    .theme-toggle {
+        gap: 0;
+        border: 1px solid var(--c-text);
+        flex-direction: column;
+    }
+
+    .theme-toggle button {
+        border-bottom: 1px solid var(--c-text);
+    }
+
+    .theme-toggle button:last-child {
+        border-bottom: 0;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add an accessible hamburger toggle button to the header
- hide the navigation on small screens and reveal it when the toggle is activated
- adjust mobile layout styles so the navigation and theme controls stack cleanly

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cc77423ff083269d401e40f03be303