### PR TITLE
Add brutal products section

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,40 @@
     </div>
 
 
+    <section class="products" id="products" aria-labelledby="products-title">
+        <div class="products-header">
+            <h2 id="products-title">BRUTAL PRODUCTS</h2>
+            <p>Tools for those who prefer sharp edges and louder statements.</p>
+        </div>
+        <div class="products-grid">
+            <article class="product-card">
+                <h3>CONCRETE POSTER</h3>
+                <p>Screen-printed on industrial stock with raw textures.</p>
+                <span class="product-price">$45</span>
+                <a href="#" class="product-link">ADD TO BAG</a>
+            </article>
+            <article class="product-card">
+                <h3>STATIC HOODIE</h3>
+                <p>Anti-comfort fleece with glitch graphics and stitched slogans.</p>
+                <span class="product-price">$95</span>
+                <a href="#" class="product-link">ADD TO BAG</a>
+            </article>
+            <article class="product-card">
+                <h3>BRUTAL ZINE VOL. 02</h3>
+                <p>32 pages of digital decay, printed in limited monochrome.</p>
+                <span class="product-price">$18</span>
+                <a href="#" class="product-link">ADD TO BAG</a>
+            </article>
+            <article class="product-card">
+                <h3>METAL PATCH SET</h3>
+                <p>Riveted badges designed to scar backpacks and denim.</p>
+                <span class="product-price">$28</span>
+                <a href="#" class="product-link">ADD TO BAG</a>
+            </article>
+        </div>
+    </section>
+
+
 
 
 

--- a/style.css
+++ b/style.css
@@ -174,6 +174,87 @@ section {
 
 }
 
+.products {
+    border-block: 1px solid var(--c-text);
+}
+
+.products-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 3rem;
+}
+
+.products-header h2 {
+    font-size: clamp(32px, 6vw, 80px);
+    letter-spacing: 2px;
+}
+
+.products-header p {
+    font-size: clamp(16px, 2vw, 22px);
+    max-width: 30ch;
+    text-transform: uppercase;
+}
+
+.products-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.product-card {
+    border: 2px solid var(--c-text);
+    padding: 2rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 260px;
+    background-image: repeating-linear-gradient(135deg, transparent 0 8px, rgba(255, 255, 255, 0.05) 8px 16px);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.product-card:hover {
+    transform: translate(-6px, -6px);
+    box-shadow: 6px 6px 0 var(--c-text);
+}
+
+.product-card h3 {
+    font-size: 1.5rem;
+    letter-spacing: 1px;
+}
+
+.product-card p {
+    flex: 1;
+    font-size: 1rem;
+}
+
+.product-price {
+    font-weight: bold;
+    font-size: 1.25rem;
+}
+
+.product-link {
+    align-self: flex-start;
+    border: 1px solid var(--c-text);
+    padding: 0.75rem 1.5rem;
+    font-weight: bold;
+    text-decoration: none;
+    display: inline-flex;
+    gap: 0.5rem;
+    background-color: var(--c-bg);
+}
+
+.product-link::after {
+    content: '→';
+}
+
+.product-link:focus-visible {
+    outline: 2px dashed var(--c-text);
+    outline-offset: 4px;
+}
+
 
 
 .grid {


### PR DESCRIPTION
## Summary
- add a dedicated products section with brutalist copy and CTA links
- style the product grid and cards to match the site's bold aesthetic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc77f44c508326999a8fc17c6aedc2