### PR TITLE
Add layered about section with overlapping imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,22 @@
         <p>Raw. Unfiltered. Direct.</p>
     </div>
 
+    <section class="about" id="about">
+        <div class="about-copy">
+            <h2>ABOUT THE STUDIO</h2>
+            <p>We craft digital experiences that embrace harsh contrasts and unapologetic geometry, letting every pixel scream with intention.</p>
+            <p>Our process rejects polish for authenticity, championing bold grids, metallic palettes, and glitch-laden motion that refuses to sit still.</p>
+            <p>From experimental interfaces to immersive brand worlds, we create brutalist narratives for rebels who dare to stand apart.</p>
+        </div>
+        <div class="about-gallery" aria-hidden="true">
+            <figure class="about-stack">
+                <img src="https://picsum.photos/640/640?random=31" alt="" loading="lazy">
+                <img src="https://picsum.photos/640/640?random=32" alt="" loading="lazy">
+                <img src="https://picsum.photos/640/640?random=33" alt="" loading="lazy">
+            </figure>
+        </div>
+    </section>
+
     <div class="grid">
         <div class="grid-item">
             <h2>RAW DESIGN</h2>

--- a/style.css
+++ b/style.css
@@ -158,6 +158,90 @@ menu button {
 
 
 
+.about {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(2rem, 8vw, 6rem);
+    align-items: center;
+    border-block: 1px solid var(--c-text);
+    padding-block: clamp(3rem, 8vw, 6rem);
+}
+
+.about h2 {
+    font-size: clamp(32px, 6vw, 72px);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+.about p + p {
+    margin-top: 1rem;
+}
+
+.about-gallery {
+    justify-self: center;
+}
+
+.about-stack {
+    position: relative;
+    width: min(100%, 420px);
+    padding-top: 120%;
+}
+
+.about-stack img {
+    position: absolute;
+    width: 68%;
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    border: 3px solid var(--c-text);
+    box-shadow: 12px 12px 0 var(--c-text);
+    background: var(--c-bg);
+    transition: transform 0.4s ease;
+}
+
+.about-stack img:nth-of-type(1) {
+    top: 0;
+    left: 0;
+    transform: rotate(-3deg);
+}
+
+.about-stack img:nth-of-type(2) {
+    top: 18%;
+    right: -8%;
+    transform: rotate(4deg);
+}
+
+.about-stack img:nth-of-type(3) {
+    bottom: -6%;
+    left: 22%;
+    transform: rotate(-6deg);
+}
+
+.about-stack img:hover {
+    transform: translate(-6px, -6px) scale(1.03);
+}
+
+@media (max-width: 900px) {
+    .about {
+        grid-template-columns: 1fr;
+        text-align: left;
+    }
+
+    .about-stack {
+        margin-inline: auto;
+        padding-top: 140%;
+    }
+
+    .about-stack img {
+        width: 75%;
+        box-shadow: 8px 8px 0 var(--c-text);
+    }
+
+    .about-stack img:nth-of-type(2) {
+        right: -2%;
+    }
+}
+
+
 section {
     background-color: var(--c-bg);
     color: var(--c-text);


### PR DESCRIPTION
## Summary
- add a dedicated About section with three paragraphs describing the studio ethos
- introduce an overlapping photo stack to reinforce the brutalist aesthetic
- style the layout for responsiveness and maintain the bold brutal feel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc78323c80832687be459546cce0d0