### PR TITLE
Add brutalist content suggestions and styleguide

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,10 +31,13 @@
             <span class="nav-toggle__bar" aria-hidden="true"></span>
         </button>
         <nav class="nav" id="primary-navigation">
-            <a href="#">HOME</a>
-            <a href="#">ABOUT</a>
-            <a href="#">WORK</a>
-            <a href="#">CONTACT</a>
+            <a href="#hero">HOME</a>
+            <a href="#about">ABOUT</a>
+            <a href="#manifesto">MANIFESTO</a>
+            <a href="#process">PROCESS</a>
+            <a href="#products">WORK</a>
+            <a href="#contact">CONTACT</a>
+            <a href="styleguide.html">STYLEGUIDE</a>
         </nav>
         <menu class="theme-toggle" aria-label="Theme toggle">
             <button type="button" data-theme="light">LIGHT</button>
@@ -42,7 +45,7 @@
         </menu>
     </header>
     
-    <div class="hero">
+    <div class="hero" id="hero">
         <h1>BRUTAL<br>DESIGN</h1>
         <p>Raw. Unfiltered. Direct.</p>
     </div>
@@ -79,6 +82,71 @@
         <p>Join the movement →</p>
     </div>
 
+
+    <section class="manifesto" id="manifesto" aria-labelledby="manifesto-title">
+        <div class="manifesto-header">
+            <h2 id="manifesto-title">BRUTALIST MANIFESTO</h2>
+            <p>Documenting the non-negotiables that guide every experiment we ship.</p>
+        </div>
+        <div>
+            <ol class="manifesto-list">
+                <li>Amplify tension between order and chaos to make users feel something.</li>
+                <li>Expose the grid, the scaffolding, and the seams—transparency is the new polish.</li>
+                <li>Celebrate system glitches as signature moves, not bugs to be hidden.</li>
+            </ol>
+            <p class="manifesto-footnote">Updated whenever the collective evolves a new instinct.</p>
+        </div>
+    </section>
+
+    <section class="process" id="process" aria-labelledby="process-title">
+        <h2 id="process-title">PROCESS // BLUEPRINT</h2>
+        <div class="process-steps">
+            <article class="process-step">
+                <span>PHASE 01</span>
+                <h3>SIGNAL INTERFERENCE</h3>
+                <p>Harvest raw cultural noise, crowd-sourced screenshots, and analog scans to build an inspiration war-room.</p>
+            </article>
+            <article class="process-step">
+                <span>PHASE 02</span>
+                <h3>BRUTAL PROTOTYPING</h3>
+                <p>Compose overlapping frames, violent color splits, and broken typography to map emotional entry points.</p>
+            </article>
+            <article class="process-step">
+                <span>PHASE 03</span>
+                <h3>PUBLIC STRESS TEST</h3>
+                <p>Deploy live prototypes, invite friction, and tune micro-interactions while the world is watching.</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="suggestions" id="suggestions" aria-labelledby="suggestions-title">
+        <div class="suggestions-header">
+            <h2 id="suggestions-title">WHAT TO SHOWCASE</h2>
+            <p>Essential content modules that give a brutalist interface the right amount of swagger.</p>
+        </div>
+        <div class="suggestions-grid">
+            <article class="suggestion-card">
+                <span>01</span>
+                <h3>DATA WALLS</h3>
+                <p>Live dashboards of community stats, drop schedules, or shipping delays keep the vibe transparent and kinetic.</p>
+            </article>
+            <article class="suggestion-card">
+                <span>02</span>
+                <h3>CASE NOISE</h3>
+                <p>Document projects like evidence boards—maps, scribbles, audio logs—to prove the process is gloriously messy.</p>
+            </article>
+            <article class="suggestion-card">
+                <span>03</span>
+                <h3>MATERIAL LIBRARY</h3>
+                <p>Texture scans, color swatches, and type stacks invite collaborators to remix the system without losing the attitude.</p>
+            </article>
+            <article class="suggestion-card">
+                <span>04</span>
+                <h3>FIELD NOTES</h3>
+                <p>Short-form essays, backstage photos, and manifesto updates keep followers plugged into the philosophy.</p>
+            </article>
+        </div>
+    </section>
 
     <section class="products" id="products" aria-labelledby="products-title">
         <div class="products-header">
@@ -134,7 +202,7 @@
         <div class="pixel-box"></div>
     </section>
 
-    <section class="brutal-form">
+    <section class="brutal-form" id="contact">
         <form>
             <input type="text" placeholder="YOUR NAME" class="brutal-input">
             <input type="email" placeholder="YOUR EMAIL" class="brutal-input">

--- a/style.css
+++ b/style.css
@@ -19,6 +19,9 @@ a:active {
     color-scheme: dark;
     --c-text: #fff;
     --c-bg: #000;
+    --c-accent: #f9ff3f;
+    --c-accent-strong: #ff0050;
+    --c-muted: #8f8f8f;
     --ff: 'Courier New', Courier, monospace;
 }
 
@@ -26,12 +29,18 @@ a:active {
     color-scheme: light;
     --c-text: #000;
     --c-bg: #fff;
+    --c-accent: #1116ff;
+    --c-accent-strong: #ff0050;
+    --c-muted: #5a5a5a;
 }
 
 :root[data-theme="dark"] {
     color-scheme: dark;
     --c-text: #fff;
     --c-bg: #000;
+    --c-accent: #f9ff3f;
+    --c-accent-strong: #ff0050;
+    --c-muted: #8f8f8f;
 }
 
 
@@ -447,6 +456,164 @@ section {
     outline-offset: 4px;
 }
 
+.manifesto {
+    border-block: 1px solid var(--c-text);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: clamp(2rem, 6vw, 4rem);
+    align-items: start;
+}
+
+.manifesto-header h2 {
+    font-size: clamp(32px, 6vw, 88px);
+    text-transform: uppercase;
+}
+
+.manifesto-header p {
+    font-size: clamp(16px, 2vw, 22px);
+    max-width: 32ch;
+    text-transform: uppercase;
+}
+
+.manifesto-list {
+    list-style: none;
+    counter-reset: manifesto-counter;
+    display: grid;
+    gap: 1.75rem;
+}
+
+.manifesto-list li {
+    counter-increment: manifesto-counter;
+    border: 2px solid var(--c-text);
+    padding: 1.5rem;
+    font-size: clamp(18px, 2.5vw, 26px);
+    font-weight: bold;
+    position: relative;
+    text-transform: uppercase;
+    background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent);
+}
+
+.manifesto-list li::before {
+    content: counter(manifesto-counter, decimal-leading-zero);
+    position: absolute;
+    top: -22px;
+    left: -22px;
+    background: var(--c-accent);
+    color: var(--c-bg);
+    border: 2px solid var(--c-text);
+    padding: 0.5rem 0.75rem;
+    font-size: 0.85rem;
+    letter-spacing: 2px;
+}
+
+.manifesto-footnote {
+    font-size: 0.875rem;
+    color: var(--c-muted);
+    text-transform: uppercase;
+    margin-top: 1rem;
+}
+
+.process {
+    border-block: 1px solid var(--c-text);
+}
+
+.process h2 {
+    font-size: clamp(32px, 6vw, 80px);
+    text-transform: uppercase;
+    margin-bottom: 2rem;
+}
+
+.process-steps {
+    display: grid;
+    gap: 1.5rem;
+    position: relative;
+}
+
+.process-step {
+    border: 2px solid var(--c-text);
+    padding: 1.75rem;
+    display: grid;
+    gap: 0.75rem;
+    background: var(--c-bg);
+}
+
+.process-step h3 {
+    font-size: clamp(20px, 3vw, 28px);
+    text-transform: uppercase;
+}
+
+.process-step p {
+    color: var(--c-muted);
+    font-size: 1rem;
+    max-width: 60ch;
+}
+
+.process-step span {
+    font-size: 0.85rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--c-accent);
+}
+
+.suggestions {
+    border-block: 1px solid var(--c-text);
+}
+
+.suggestions-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 3rem;
+}
+
+.suggestions-header h2 {
+    font-size: clamp(32px, 5vw, 72px);
+    text-transform: uppercase;
+}
+
+.suggestions-header p {
+    font-size: clamp(16px, 2vw, 22px);
+    max-width: 46ch;
+    text-transform: uppercase;
+}
+
+.suggestions-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.suggestion-card {
+    border: 2px solid var(--c-text);
+    padding: 1.75rem;
+    display: grid;
+    gap: 0.75rem;
+    background: var(--c-bg);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.suggestion-card:hover {
+    transform: translate(-6px, -6px);
+    box-shadow: 6px 6px 0 var(--c-text);
+}
+
+.suggestion-card h3 {
+    font-size: clamp(18px, 2.5vw, 26px);
+    text-transform: uppercase;
+}
+
+.suggestion-card p {
+    font-size: 0.95rem;
+    color: var(--c-muted);
+}
+
+.suggestion-card span {
+    font-size: 0.75rem;
+    letter-spacing: 2px;
+    color: var(--c-accent);
+    text-transform: uppercase;
+}
+
 
 
 .grid {
@@ -471,7 +638,7 @@ section {
     padding: 20px;
     text-align: center;
     /* margin: 20px; */
-    border: 5px solid #000;
+    border: 5px solid var(--c-text);
     /* cursor: pointer; */
 
     border-top: 1px solid var(--c-text);
@@ -509,7 +676,7 @@ section {
 }
 
 .gallery-item {
-    border: 3px solid var(--accent-color);
+    border: 3px solid var(--c-text);
 
 
 
@@ -587,19 +754,17 @@ section {
     /* border: 3px solid var(--text-color); */
     font-family: inherit;
     font-size: 18px;
-    background: var(--background-color);
-
-
+    background: var(--c-bg);
+    color: var(--c-text);
     border: 1px solid var(--c-text);
-
 }
 
 .brutal-button {
     width: 100%;
     padding: 20px;
-    background: var(--accent-color);
-    border: 3px solid var(--text-color);
-    color: var(--text-color);
+    background: var(--c-accent);
+    border: 3px solid var(--c-text);
+    color: var(--c-bg);
     font-size: 24px;
     cursor: pointer;
     transition: transform 0.2s;
@@ -607,7 +772,7 @@ section {
 
 .brutal-button:hover {
     transform: translate(-5px, -5px);
-    box-shadow: 5px 5px 0 var(--text-color);
+    box-shadow: 5px 5px 0 var(--c-text);
 }
 
 
@@ -657,7 +822,7 @@ section {
     border-top: 1px solid var(--c-text);
     background-color: var(--c-bg);
     color: var(--c-text);
-    
+
     padding-inline: 3em;
     /* padding-inline: 6em; */
     /* padding-block: 3em;*/
@@ -671,7 +836,7 @@ section {
     gap: 40px;
 
     /* padding-block: 6em; */
-    padding-block: 4em; 
+    padding-block: 4em;
 }
 
 .footer-item a {
@@ -686,5 +851,143 @@ section {
 
 .footer-bottom {
     /* border-top: 1px solid var(--c-text); */
-    padding-block: 2em;  
+    padding-block: 2em;
+}
+
+.styleguide-main {
+    padding-inline: clamp(2rem, 8vw, 6rem);
+    padding-block: clamp(3rem, 8vw, 6rem);
+    display: grid;
+    gap: clamp(3rem, 6vw, 4.5rem);
+}
+
+.styleguide-main h1 {
+    font-size: clamp(40px, 8vw, 96px);
+    text-transform: uppercase;
+}
+
+.styleguide-main p {
+    max-width: 62ch;
+}
+
+.styleguide-section {
+    border: 2px solid var(--c-text);
+    padding: clamp(1.5rem, 5vw, 3rem);
+    background: var(--c-bg);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.styleguide-section h2 {
+    font-size: clamp(24px, 5vw, 48px);
+    text-transform: uppercase;
+}
+
+.swatch-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.swatch {
+    border: 2px solid var(--c-text);
+    padding: 1.5rem 1rem;
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.swatch.is-dark {
+    background: #000;
+    color: #fff;
+}
+
+.swatch.is-light {
+    background: #fff;
+    color: #000;
+}
+
+.swatch.is-accent {
+    background: var(--c-accent);
+    color: var(--c-bg);
+}
+
+.type-stack {
+    display: grid;
+    gap: 1rem;
+}
+
+.type-sample {
+    border: 2px solid var(--c-text);
+    padding: 1.5rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.type-sample span {
+    font-size: 0.8rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--c-muted);
+}
+
+.component-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.component-preview {
+    border: 2px solid var(--c-text);
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.component-preview h3 {
+    font-size: 1rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.component-preview .demo-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.component-preview .demo-buttons button,
+.component-preview .demo-buttons a {
+    border: 2px solid var(--c-text);
+    padding: 0.75rem 1.5rem;
+    background: var(--c-bg);
+    text-transform: uppercase;
+    font-weight: bold;
+    color: var(--c-text);
+    cursor: pointer;
+}
+
+.component-preview .demo-buttons button.is-accent,
+.component-preview .demo-buttons a.is-accent {
+    background: var(--c-accent);
+    color: var(--c-bg);
+}
+
+.component-preview .demo-card {
+    border: 2px solid var(--c-text);
+    padding: 1rem;
+    display: grid;
+    gap: 0.5rem;
+    background-image: repeating-linear-gradient(135deg, transparent 0 10px, rgba(255, 255, 255, 0.05) 10px 20px);
+}
+
+.styleguide-callout {
+    border: 2px dashed var(--c-text);
+    padding: 1.5rem;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    display: grid;
+    gap: 0.5rem;
 }

--- a/styleguide.html
+++ b/styleguide.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Brutal Design Styleguide</title>
+    <script>
+        (function () {
+            try {
+                const storedTheme = localStorage.getItem('theme');
+                if (storedTheme) {
+                    document.documentElement.setAttribute('data-theme', storedTheme);
+                }
+            } catch (error) {
+                /* localStorage might be unavailable (e.g. privacy mode). */
+            }
+        })();
+    </script>
+</head>
+<body>
+    <header>
+        <button type="button" class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+            <span class="nav-toggle__bar" aria-hidden="true"></span>
+        </button>
+        <nav class="nav" id="primary-navigation">
+            <a href="index.html#hero">HOME</a>
+            <a href="index.html#about">ABOUT</a>
+            <a href="index.html#manifesto">MANIFESTO</a>
+            <a href="index.html#process">PROCESS</a>
+            <a href="index.html#products">WORK</a>
+            <a href="index.html#contact">CONTACT</a>
+            <a aria-current="page" href="styleguide.html">STYLEGUIDE</a>
+        </nav>
+        <menu class="theme-toggle" aria-label="Theme toggle">
+            <button type="button" data-theme="light">LIGHT</button>
+            <button type="button" data-theme="dark">DARK</button>
+        </menu>
+    </header>
+
+    <main class="styleguide-main">
+        <section class="styleguide-section">
+            <h1>Brutalist Interface Styleguide</h1>
+            <p>This companion page documents the core ingredients of the demo—use it to keep future pages aligned with the studio’s raw identity.</p>
+            <div class="styleguide-callout">
+                <span>Pro Tip</span>
+                <p>Mix high-contrast blocks with generous negative space. Brutalism thrives on tension between rigid systems and loud disruptions.</p>
+            </div>
+        </section>
+
+        <section class="styleguide-section" id="color-system">
+            <h2>Color System</h2>
+            <p>Lean on a monochrome base and deploy accent shots sparingly for moments of emphasis or interaction.</p>
+            <div class="swatch-grid">
+                <div class="swatch is-dark">
+                    <strong>Background</strong>
+                    <span>#000000</span>
+                </div>
+                <div class="swatch is-light">
+                    <strong>Foreground</strong>
+                    <span>#FFFFFF</span>
+                </div>
+                <div class="swatch is-accent">
+                    <strong>Accent</strong>
+                    <span>var(--c-accent)</span>
+                </div>
+                <div class="swatch">
+                    <strong>Signal Red</strong>
+                    <span>var(--c-accent-strong)</span>
+                </div>
+                <div class="swatch">
+                    <strong>Muted</strong>
+                    <span>var(--c-muted)</span>
+                </div>
+            </div>
+        </section>
+
+        <section class="styleguide-section" id="typography">
+            <h2>Typography</h2>
+            <p>Typography is utilitarian and loud. Use monospace families to echo terminal aesthetics and set generous tracking for titles.</p>
+            <div class="type-stack">
+                <div class="type-sample">
+                    <span>Display</span>
+                    <h2>BRUTAL DESIGN NETWORK</h2>
+                    <p>Clamp sizing keeps the headline responsive without losing its impact.</p>
+                </div>
+                <div class="type-sample">
+                    <span>Body</span>
+                    <p>Body copy keeps the pace steady. Maintain 1.6 line height and limit paragraphs to 60 characters per line to balance legibility with aggression.</p>
+                </div>
+                <div class="type-sample">
+                    <span>Meta Labels</span>
+                    <p style="letter-spacing: 0.35em; text-transform: uppercase;">SUBHEADS SHOULD FEEL LIKE STAMPED LABELS.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="styleguide-section" id="layout">
+            <h2>Layout &amp; Grid</h2>
+            <p>Keep the grid visible. Use thick rules, exposed borders, and layered cards to create depth without gradients.</p>
+            <ul>
+                <li>Use 2–4 column layouts with generous gutters for desktop, collapsing to a single column on mobile.</li>
+                <li>Border weight should stay between 2–3px for structural elements.</li>
+                <li>Alternate block rotations or offsets by 2–6 degrees to keep compositions unsettled.</li>
+            </ul>
+        </section>
+
+        <section class="styleguide-section" id="components">
+            <h2>Core Components</h2>
+            <div class="component-grid">
+                <div class="component-preview">
+                    <h3>Buttons</h3>
+                    <div class="demo-buttons">
+                        <button type="button">Default Action</button>
+                        <button type="button" class="is-accent">Accent Action</button>
+                    </div>
+                    <p>Pair heavy borders with abrupt hover states. Consider animating subtle translations for tactile feedback.</p>
+                </div>
+                <div class="component-preview">
+                    <h3>Cards</h3>
+                    <div class="demo-card">
+                        <span style="letter-spacing: 0.4em;">CASE 07</span>
+                        <strong>Signal Jam UI</strong>
+                        <p>Evidence of layered textures, glitch artifacts, and unapologetic copywriting.</p>
+                    </div>
+                    <p>Cards may rotate slightly or stack like print proofs. Keep the border visible at all times.</p>
+                </div>
+                <div class="component-preview">
+                    <h3>Form Elements</h3>
+                    <div class="demo-card">
+                        <label for="demo-name">YOUR NAME</label>
+                        <input id="demo-name" type="text" class="brutal-input" placeholder="JOAN DOE">
+                        <label for="demo-email">YOUR EMAIL</label>
+                        <input id="demo-email" type="email" class="brutal-input" placeholder="HEY@BRUTAL.STUDIO">
+                    </div>
+                    <p>Inputs stay flat with one-pixel offsets. Use uppercase placeholders and high-contrast focus states.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="styleguide-section" id="motion">
+            <h2>Motion &amp; Interaction</h2>
+            <ul>
+                <li>Introduce micro-glitches via keyframe jitter or blend-mode overlays.</li>
+                <li>Prefer linear, snappy transitions (0.2–0.3s) to maintain the brutalist punch.</li>
+                <li>Scroll-triggered marquee or ticker elements add rhythm without needing video.</li>
+            </ul>
+        </section>
+    </main>
+
+    <footer class="brutal-footer">
+        <div class="footer-grid">
+            <div class="footer-item">
+                <h3>BRUTAL STUDIO</h3>
+                <p>STYLEGUIDE 2024</p>
+            </div>
+            <div class="footer-item">
+                <h3>LINKS</h3>
+                <a href="index.html#hero">RETURN TO DEMO</a>
+                <a href="index.html#suggestions">CONTENT IDEAS</a>
+                <a href="index.html#products">SHOP MODULE</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>© BRUTAL DESIGN SYSTEM 2024</p>
+        </div>
+    </footer>
+
+    <script>
+        (function () {
+            const THEME_STORAGE_KEY = 'theme';
+            const root = document.documentElement;
+            const toggleButtons = document.querySelectorAll('.theme-toggle [data-theme]');
+
+            function applyTheme(theme) {
+                root.setAttribute('data-theme', theme);
+                toggleButtons.forEach((button) => {
+                    const isActive = button.dataset.theme === theme;
+                    button.classList.toggle('is-active', isActive);
+                    button.setAttribute('aria-pressed', String(isActive));
+                });
+            }
+
+            let storedTheme = null;
+            try {
+                storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+            } catch (error) {
+                storedTheme = null;
+            }
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const initialTheme = storedTheme || (prefersDark ? 'dark' : 'light');
+            applyTheme(initialTheme);
+
+            toggleButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    const theme = button.dataset.theme;
+                    applyTheme(theme);
+                    try {
+                        localStorage.setItem(THEME_STORAGE_KEY, theme);
+                    } catch (error) {
+                        /* localStorage might be unavailable (e.g. privacy mode). */
+                    }
+                });
+            });
+        })();
+
+        (function () {
+            const nav = document.querySelector('.nav');
+            const toggle = document.querySelector('.nav-toggle');
+            if (!nav || !toggle) {
+                return;
+            }
+
+            function closeNav() {
+                toggle.setAttribute('aria-expanded', 'false');
+                nav.classList.remove('is-open');
+            }
+
+            toggle.addEventListener('click', () => {
+                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                const nextState = !isExpanded;
+                toggle.setAttribute('aria-expanded', String(nextState));
+                nav.classList.toggle('is-open', nextState);
+            });
+
+            nav.querySelectorAll('a').forEach((link) => {
+                link.addEventListener('click', () => {
+                    if (window.matchMedia('(max-width: 768px)').matches) {
+                        closeNav();
+                    }
+                });
+            });
+
+            const mq = window.matchMedia('(min-width: 769px)');
+            if (typeof mq.addEventListener === 'function') {
+                mq.addEventListener('change', closeNav);
+            } else if (typeof mq.addListener === 'function') {
+                mq.addListener(closeNav);
+            }
+
+            closeNav();
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand the landing page navigation and sections with a manifesto, process timeline, and content suggestions tailored for a brutalist UI
- tune the shared stylesheet with reusable accent variables and styling for the new sections
- add a dedicated styleguide page highlighting colors, typography, layout rules, and component previews for the theme

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd73a124988326a84702020f0003d0