### PR TITLE
Add categorized project archive section

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         })();
     </script>
 </head>
-<body>
+<body id="top">
 
     <header>
         <button type="button" class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
@@ -31,10 +31,10 @@
             <span class="nav-toggle__bar" aria-hidden="true"></span>
         </button>
         <nav class="nav" id="primary-navigation">
-            <a href="#">HOME</a>
-            <a href="#">ABOUT</a>
-            <a href="#">WORK</a>
-            <a href="#">CONTACT</a>
+            <a href="#top">HOME</a>
+            <a href="#about">ABOUT</a>
+            <a href="#projects">WORK</a>
+            <a href="#contact">CONTACT</a>
         </nav>
         <menu class="theme-toggle" aria-label="Theme toggle">
             <button type="button" data-theme="light">LIGHT</button>
@@ -78,6 +78,99 @@
         <h2>EMBRACE THE BRUTAL</h2>
         <p>Join the movement →</p>
     </div>
+
+
+
+
+    <section class="projects" id="projects" aria-labelledby="projects-title">
+        <div class="projects-header">
+            <h2 id="projects-title">PROJECT ARCHIVE</h2>
+            <p>Selected collaborations arranged by the chaos they unleashed.</p>
+        </div>
+        <div class="projects-grid">
+            <article class="project-category">
+                <h3>DIGITAL INTERFACES</h3>
+                <p class="project-category-description">Web experiences for brands that refuse to whisper.</p>
+                <ul class="project-list">
+                    <li class="project-item">
+                        <div>
+                            <strong>Static Pulse Platform</strong>
+                            <p class="project-tags">E-commerce · Motion UX</p>
+                        </div>
+                        <span class="project-year">2024</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Greywave Newsroom</strong>
+                            <p class="project-tags">Editorial · Accessibility</p>
+                        </div>
+                        <span class="project-year">2023</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Voltage CRM</strong>
+                            <p class="project-tags">SaaS · System Design</p>
+                        </div>
+                        <span class="project-year">2022</span>
+                    </li>
+                </ul>
+            </article>
+            <article class="project-category">
+                <h3>BRAND WORLDS</h3>
+                <p class="project-category-description">Identity systems built with concrete grids and raw type.</p>
+                <ul class="project-list">
+                    <li class="project-item">
+                        <div>
+                            <strong>Obsidian Athletics</strong>
+                            <p class="project-tags">Branding · Campaign</p>
+                        </div>
+                        <span class="project-year">2024</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Iconoclast Studios</strong>
+                            <p class="project-tags">Strategy · Art Direction</p>
+                        </div>
+                        <span class="project-year">2023</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Sever &amp; Co.</strong>
+                            <p class="project-tags">Identity · Packaging</p>
+                        </div>
+                        <span class="project-year">2022</span>
+                    </li>
+                </ul>
+            </article>
+            <article class="project-category">
+                <h3>IMMERSIVE INSTALLATIONS</h3>
+                <p class="project-category-description">Physical-digital hybrids that light up brutalist spaces.</p>
+                <ul class="project-list">
+                    <li class="project-item">
+                        <div>
+                            <strong>Neon Verge Pavilion</strong>
+                            <p class="project-tags">Interactive · Sound Design</p>
+                        </div>
+                        <span class="project-year">2023</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Concrete Chorus</strong>
+                            <p class="project-tags">Projection · Public Art</p>
+                        </div>
+                        <span class="project-year">2022</span>
+                    </li>
+                    <li class="project-item">
+                        <div>
+                            <strong>Signal Warden</strong>
+                            <p class="project-tags">AR · Performance</p>
+                        </div>
+                        <span class="project-year">2021</span>
+                    </li>
+                </ul>
+            </article>
+        </div>
+    </section>
 
 
     <section class="products" id="products" aria-labelledby="products-title">
@@ -134,7 +227,7 @@
         <div class="pixel-box"></div>
     </section>
 
-    <section class="brutal-form">
+    <section class="brutal-form" id="contact">
         <form>
             <input type="text" placeholder="YOUR NAME" class="brutal-input">
             <input type="email" placeholder="YOUR EMAIL" class="brutal-input">

--- a/style.css
+++ b/style.css
@@ -366,6 +366,117 @@ section {
 
 }
 
+.projects {
+    border-block: 1px solid var(--c-text);
+    display: grid;
+    gap: clamp(2.5rem, 7vw, 4.5rem);
+}
+
+.projects-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1.25rem;
+}
+
+.projects-header h2 {
+    font-size: clamp(32px, 6vw, 80px);
+    letter-spacing: 2px;
+}
+
+.projects-header p {
+    font-size: clamp(16px, 2vw, 22px);
+    max-width: 36ch;
+    text-transform: uppercase;
+}
+
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.project-category {
+    border: 2px solid var(--c-text);
+    padding: clamp(1.75rem, 4vw, 2.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    background-color: var(--c-bg);
+    box-shadow: 8px 8px 0 var(--c-text);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-category:hover {
+    transform: translate(-6px, -6px);
+    box-shadow: 12px 12px 0 var(--c-text);
+}
+
+.project-category h3 {
+    font-size: clamp(20px, 3vw, 28px);
+    letter-spacing: 2px;
+}
+
+.project-category-description {
+    font-size: clamp(14px, 2vw, 18px);
+    max-width: 32ch;
+    text-transform: uppercase;
+    opacity: 0.85;
+}
+
+.project-list {
+    list-style: none;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.project-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    border-top: 1px solid var(--c-text);
+    padding-top: 1rem;
+}
+
+.project-item:first-child {
+    border-top: 0;
+    padding-top: 0;
+}
+
+.project-item strong {
+    font-size: 1.05rem;
+    letter-spacing: 1px;
+}
+
+.project-tags {
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    opacity: 0.75;
+}
+
+.project-year {
+    align-self: flex-start;
+    padding: 0.2rem 0.85rem;
+    border: 1px solid var(--c-text);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+}
+
+@media (max-width: 640px) {
+    .project-item {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .project-year {
+        margin-top: 0.5rem;
+    }
+}
+
 .products {
     border-block: 1px solid var(--c-text);
 }


### PR DESCRIPTION
## Summary
- add anchor targets for navigation links to jump to top, about, projects, and contact sections
- introduce a project archive section that highlights agency work across three categories with supporting metadata
- style the archive with brutalist-inspired cards and responsive layouts that match the existing aesthetic

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd742b5db48326b7945bd203d5dae4